### PR TITLE
Implemented travisCI into project and added travis badge to the readme

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+cache: bundler
+language: ruby
+rvm:
+  - "2.3.0"
+
+#branches:
+#  only:
+#    - master
+
+script: bundle exec rspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    payfort_start (0.0.4)
+    payfort_start (0.0.5)
       httparty (~> 0.13)
       json (~> 1.8)
 
@@ -42,3 +42,6 @@ DEPENDENCIES
   byebug
   payfort_start!
   rspec
+
+BUNDLED WITH
+   1.11.2

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Start Ruby
+# Start Ruby [![Build Status](https://travis-ci.org/SundayAdefila/start-ruby.svg?branch=integrating-travisCI)](https://travis-ci.org/SundayAdefila/start-ruby)
 
 Payfort Start makes accepting payments in the Middle East ridiculously easy. Sign up for an account at [start.payfort.com](https://start.payfort.com).
 


### PR DESCRIPTION
The badge included: 
`[![Build Status](https://travis-ci.org/SundayAdefila/start-ruby.svg?branch=integrating-travisCI)](https://travis-ci.org/SundayAdefila/start-ruby)` 

will have to be changed to reflect one from a free Payfort travis account. ( I can do this if/after this PR is accepted, and I got added to contributors. )

This will appear on the repository readme as follow:

<img width="328" alt="screen shot 2016-05-26 at 5 50 46 pm" src="https://cloud.githubusercontent.com/assets/16901749/15582787/a64c9e62-236a-11e6-88da-25f6a5260004.png">

To show the state of the tests.